### PR TITLE
[FEAT] Add Dapr Environments for Startup

### DIFF
--- a/src/Wemogy.AspNet/Dapr/DaprEnvironment.cs
+++ b/src/Wemogy.AspNet/Dapr/DaprEnvironment.cs
@@ -1,0 +1,17 @@
+namespace Wemogy.AspNet.Dapr
+{
+    public class DaprEnvironment
+    {
+        public bool UseCloudEvents { get; private set; }
+
+        public DaprEnvironment()
+        {
+        }
+
+        public DaprEnvironment WithCloudEvents()
+        {
+            UseCloudEvents = true;
+            return this;
+        }
+    }
+}

--- a/src/Wemogy.AspNet/Startup/StartupOptions.cs
+++ b/src/Wemogy.AspNet/Startup/StartupOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using Wemogy.AspNet.Dapr;
 using Wemogy.AspNet.Monitoring;
 using Wemogy.AspNet.Swagger;
 using Wemogy.Core.Monitoring;
@@ -11,6 +12,7 @@ public class StartupOptions
 {
     internal OpenApiEnvironment? OpenApiEnvironment { get; private set; }
     internal MonitoringEnvironment? MonitoringEnvironment { get; private set; }
+    internal DaprEnvironment? DaprEnvironment { get; private set; }
 
     public StartupOptions()
     {
@@ -31,5 +33,14 @@ public class StartupOptions
     {
         MonitoringEnvironment = new MonitoringEnvironment(serviceName);
         return MonitoringEnvironment;
+    }
+
+    /// <summary>
+    /// Ensures, that Dapr is added to the application and registers the Dapr middleware.
+    /// </summary>
+    public DaprEnvironment AddDapr()
+    {
+        DaprEnvironment = new DaprEnvironment();
+        return DaprEnvironment;
     }
 }

--- a/src/Wemogy.AspNet/Wemogy.AspNet.csproj
+++ b/src/Wemogy.AspNet/Wemogy.AspNet.csproj
@@ -39,5 +39,6 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
     <PackageReference Include="Wemogy.Core" Version="1.1.1" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.10.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Would look like this

```csharp
public class Startup
{
    private readonly StartupOptions _options;

    public Startup(IConfiguration configuration)
    {
        Configuration = configuration;

        _options = new StartupOptions();

        // Add Swagger
        _options
            .AddOpenApi("v1")
            .WithApiGroup("public", "Wemogy.Media.WebServices.Orchestrator API", "This is the Wemogy.Media.WebServices.Orchestrator API.");

        // Add Monitoring
        _options
            .AddMonitoring(Configuration["AzureApplicationInsightsCloudRole"] ?? string.Empty)
            .WithApplicationInsights(Configuration["AzureApplicationInsightsConnectionString"] ?? string.Empty);

        // Add Dapr
        _options
            .AddDapr()
            .WithCloudEvents();
    }
```