### PR TITLE
Added health checks endpoint to UseDefaultEndpoints

### DIFF
--- a/src/Wemogy.AspNet/Startup/StartupExtensions.cs
+++ b/src/Wemogy.AspNet/Startup/StartupExtensions.cs
@@ -150,6 +150,7 @@ namespace Wemogy.AspNet.Startup
             applicationBuilder.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
+                endpoints.MapHealthChecks("/healthz");
             });
         }
 


### PR DESCRIPTION
We just called `MapHealthChecks` if `options.DaprEnvironment` is not null. But in default mode, we also want to have the health checks endpoint